### PR TITLE
Add thorough unit tests for App interactions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -74,7 +74,12 @@ function App() {
   return (
     <div style={{ maxWidth: "600px", margin: "50px auto", textAlign: "center" }}>
       <h1>Tennis AI Coach</h1>
-      <input type="file" accept="image/*" onChange={handleImageChange} />
+      <input
+        aria-label="Upload swing photo"
+        type="file"
+        accept="image/*"
+        onChange={handleImageChange}
+      />
       {compressedPreview && (
         <div style={{ marginTop: "10px" }}>
           <p>Compressed Image Preview:</p>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,148 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import axios from "axios";
+import imageCompression from "browser-image-compression";
+import App from "./App";
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock(
+  "axios",
+  () => ({
+    post: jest.fn(),
+  }),
+  { virtual: true }
+);
+
+jest.mock("browser-image-compression", () => jest.fn());
+
+const mockDataUrl = "data:image/jpeg;base64,mock-result";
+
+class MockFileReader {
+  constructor() {
+    this.onload = null;
+    this.result = null;
+    this.readAsDataURL = jest.fn(() => {
+      this.result = mockDataUrl;
+      setTimeout(() => {
+        if (this.onload) {
+          this.onload({ target: { result: this.result } });
+        }
+      }, 0);
+    });
+    MockFileReader.instances.push(this);
+  }
+}
+
+MockFileReader.instances = [];
+
+describe("App", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockFileReader.instances = [];
+    window.FileReader = MockFileReader;
+    global.FileReader = MockFileReader;
+  });
+
+  test("renders the main heading and analyze button", () => {
+    render(<App />);
+
+    expect(
+      screen.getByRole("heading", { name: /tennis ai coach/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /analyze/i })).toBeInTheDocument();
+  });
+
+  test("compresses an uploaded image and shows a preview", async () => {
+    const compressedBlob = new Blob(["compressed"], { type: "image/jpeg" });
+    imageCompression.mockResolvedValue(compressedBlob);
+
+    render(<App />);
+
+    const fileInput = screen.getByLabelText(/upload swing photo/i);
+    const file = new File(["swing"], "swing.jpg", { type: "image/jpeg" });
+
+    await userEvent.upload(fileInput, file);
+
+    await waitFor(() => expect(imageCompression).toHaveBeenCalled());
+
+    expect(imageCompression).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining({
+        maxSizeMB: 0.5,
+        maxWidthOrHeight: 800,
+        useWebWorker: true,
+      })
+    );
+
+    await waitFor(() =>
+      expect(MockFileReader.instances.length).toBeGreaterThan(0)
+    );
+
+    const readerInstance = MockFileReader.instances[0];
+    expect(readerInstance.readAsDataURL).toHaveBeenCalledWith(compressedBlob);
+
+    expect(await screen.findByText(/compressed image preview/i)).toBeInTheDocument();
+    expect(await screen.findByAltText(/preview/i)).toHaveAttribute("src", mockDataUrl);
+  });
+
+  test("calls the OpenAI API and displays feedback after analyzing", async () => {
+    imageCompression.mockResolvedValue(new Blob(["compressed"], { type: "image/jpeg" }));
+
+    const feedbackText = "Great follow-through.";
+    let resolvePost;
+    axios.post.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = () => resolve({ data: { output_text: feedbackText } });
+        })
+    );
+
+    render(<App />);
+
+    const fileInput = screen.getByLabelText(/upload swing photo/i);
+    const file = new File(["swing"], "swing.jpg", { type: "image/jpeg" });
+
+    await userEvent.upload(fileInput, file);
+
+    await waitFor(() =>
+      expect(MockFileReader.instances.length).toBeGreaterThan(0)
+    );
+
+    await screen.findByAltText(/preview/i);
+
+    const analyzeButton = screen.getByRole("button", { name: /analyze/i });
+    await userEvent.click(analyzeButton);
+
+    await waitFor(() =>
+      expect(analyzeButton).toHaveTextContent(/analyzing/i)
+    );
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/responses",
+      expect.objectContaining({
+        model: "gpt-4o-mini",
+        input: [
+          expect.objectContaining({
+            content: expect.arrayContaining([
+              expect.objectContaining({ type: "input_text" }),
+              expect.objectContaining({ type: "input_image", image_url: mockDataUrl }),
+            ]),
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer ",
+        }),
+      })
+    );
+
+    resolvePost();
+
+    await waitFor(() =>
+      expect(analyzeButton).toHaveTextContent(/^Analyze$/i)
+    );
+
+    expect(await screen.findByText(feedbackText)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add an accessible label to the file input to simplify selection in tests
- replace the placeholder CRA test with coverage for image upload and preview compression logic
- verify the OpenAI analysis request/response flow by mocking axios and browser-image-compression

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d1afad4130832fa6acb2162f032b3d